### PR TITLE
Use xUnit for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
                 name: Publish test report
                 uses: ctrf-io/github-test-reporter@v1
                 with:
-                    report-path: ./test-results/*.json
+                    report-path: ./test-results/*.ctrf
                     github-report: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,10 @@ jobs:
                 uses: actions/checkout@v6
             -   uses: ./.github/actions/setup-environment
             -   name: Test
-                run: dotnet test -c Release
+                run: dotnet test -c Release --results-directory ./test-results -- --report-ctrf
+            -   if: always()
+                name: Publish test report
+                uses: ctrf-io/github-test-reporter@v1
+                with:
+                    report-path: ./test-results/*.json
+                    github-report: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,7 @@ jobs:
                 uses: ctrf-io/github-test-reporter@v1
                 with:
                     report-path: ./test-results/*.ctrf
-                    github-report: true
+                    summary-report: true
+                    suite-folded-report: true
+                    failed-folded-report: true
+                    skipped-report: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
                 with:
                     report-path: ./test-results/*.ctrf
                     summary-report: true
-                    suite-folded-report: true
+                    file-report: true
                     failed-folded-report: true
                     skipped-report: true

--- a/renovate.json
+++ b/renovate.json
@@ -24,16 +24,5 @@
                 "\"library\": ?\"(?<depName>@?[^\"]+?)@(?<currentValue>.*?)\""
             ]
         }
-    ],
-    "packageRules": [
-        {
-            "description": "Schedule TUnit.Engine updates on early Monday mornings (before 4 AM)",
-            "matchPackageNames": [
-                "TUnit.Engine"
-            ],
-            "schedule": [
-                "* 0-3 * * 1"
-            ]
-        }
     ]
 }

--- a/tests/SmoothNanners.Web.Tests.Integration/AppFactory.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/AppFactory.cs
@@ -1,20 +1,21 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Testing.Platform.Services;
+using Microsoft.Extensions.Logging;
 using System.Net;
 using System.Net.Sockets;
 
 namespace SmoothNanners.Web.Tests.Integration;
 
-internal sealed class AppFactory : WebApplicationFactory<Program>
+public sealed class AppFactory : WebApplicationFactory<Program>
 {
     private IHost? _host;
 
     public AppFactory()
     {
-        // Ensure the server is created.
+        // Ensure the host is created.
         _ = Server;
 
         LinkGenerator = _host!.Services.GetRequiredService<LinkGenerator>();
@@ -37,9 +38,7 @@ internal sealed class AppFactory : WebApplicationFactory<Program>
         var dummyHost = builder.Build();
 
 #pragma warning disable IDISP003
-        _host = builder
-            .ConfigureWebHost(b => b.UseSetting("Kestrel:Endpoints:Http:Url", BaseUrl).UseKestrel())
-            .Build();
+        _host = builder.ConfigureWebHost(b => b.UseSetting("Kestrel:Endpoints:Http:Url", BaseUrl).UseKestrel()).Build();
 #pragma warning restore IDISP003
 
         _host.Start();

--- a/tests/SmoothNanners.Web.Tests.Integration/AssemblyInfo.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using SmoothNanners.Web.Tests.Integration;
+using Xunit.v3;
+
+[assembly: TestPipelineStartup(typeof(AssemblySetup))]
+[assembly: AssemblyFixture(typeof(TestFixture))]

--- a/tests/SmoothNanners.Web.Tests.Integration/AssemblySetup.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/AssemblySetup.cs
@@ -4,6 +4,9 @@ using Xunit.v3;
 
 namespace SmoothNanners.Web.Tests.Integration;
 
+/// <summary>
+/// Setup for the assembly that runs early in the test pipeline during discovery and execution.
+/// </summary>
 internal sealed class AssemblySetup : ITestPipelineStartup
 {
     public ValueTask StartAsync(IMessageSink diagnosticMessageSink)

--- a/tests/SmoothNanners.Web.Tests.Integration/AssemblySetup.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/AssemblySetup.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Playwright.TestAdapter;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace SmoothNanners.Web.Tests.Integration;
+
+internal sealed class AssemblySetup : ITestPipelineStartup
+{
+    public ValueTask StartAsync(IMessageSink diagnosticMessageSink)
+    {
+        // Install browser binaries needed for Playwright.
+        var exitCode = Microsoft.Playwright.Program.Main(["install", PlaywrightSettingsProvider.BrowserName]);
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException($"Playwright browser install exited with code [{exitCode}].");
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/SmoothNanners.Web.Tests.Integration/Pages/ErrorTests.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/Pages/ErrorTests.cs
@@ -6,10 +6,15 @@ namespace SmoothNanners.Web.Tests.Integration.Pages;
 
 public sealed class ErrorTests : TestBase
 {
-    [Test]
-    [Arguments(HttpStatusCode.OK, HttpStatusCode.BadRequest)]
-    [Arguments(HttpStatusCode.InternalServerError, HttpStatusCode.InternalServerError)]
-    [Arguments(HttpStatusCode.NotFound, HttpStatusCode.NotFound, "The page you are looking for was not found.")]
+    public ErrorTests(TestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.OK, HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.InternalServerError, HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.NotFound, HttpStatusCode.NotFound, "The page you are looking for was not found.")]
     public async Task Error_Loads_Successfully_WithNoCache(
         HttpStatusCode code,
         HttpStatusCode expectedResponseCode,
@@ -23,21 +28,25 @@ public sealed class ErrorTests : TestBase
         var response = await page.GotoAsync(path);
 
         // Assert
-        response!.Status.ShouldBe((int)expectedResponseCode);
-        (await response.HeaderValueAsync(HeaderNames.CacheControl)).ShouldBe("no-store,no-cache");
-        (await response.HeaderValueAsync(HeaderNames.Pragma)).ShouldBe("no-cache");
-        (await response.HeaderValueAsync(HeaderNames.Age)).ShouldBeNull();
+        response!.Status.Should().Be((int)expectedResponseCode);
+        (await response.HeaderValueAsync(HeaderNames.CacheControl)).Should().Be("no-store,no-cache");
+        (await response.HeaderValueAsync(HeaderNames.Pragma)).Should().Be("no-cache");
+        (await response.HeaderValueAsync(HeaderNames.Age)).Should().BeNull();
 
-        (await page.Locator("head > title").TextContentAsync()).ShouldBe(
-            $"Error: {(int)expectedResponseCode} | {AppConstants.SiteName}");
-        (await page.Locator("head > meta[name='robots']").GetAttributeAsync("content")).ShouldBe("noindex");
+        (await page.Locator("head > title").TextContentAsync())
+            .Should()
+            .Be($"Error: {(int)expectedResponseCode} | {AppConstants.SiteName}");
+
+        (await page.Locator("head > meta[name='robots']").GetAttributeAsync("content")).Should().Be("noindex");
 
         var errorHeading = page.Locator("body > div > main h2").First;
-        (await errorHeading.TextContentAsync()).ShouldBe($"Error: {(int)expectedResponseCode}");
+        (await errorHeading.TextContentAsync()).Should().Be($"Error: {(int)expectedResponseCode}");
 
         var errorMessage = errorHeading.Locator("//following-sibling::p[1]");
-        (await errorMessage.TextContentAsync()).ShouldBe(expectedMessage);
+        (await errorMessage.TextContentAsync()).Should().Be(expectedMessage);
 
-        (await page.Locator("body > div > main a").GetByText("Back to Home").GetAttributeAsync("href")).ShouldBe("/");
+        (await page.Locator("body > div > main a").GetByText("Back to Home").GetAttributeAsync("href"))
+            .Should()
+            .Be("/");
     }
 }

--- a/tests/SmoothNanners.Web.Tests.Integration/Pages/IndexTests.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/Pages/IndexTests.cs
@@ -7,7 +7,12 @@ namespace SmoothNanners.Web.Tests.Integration.Pages;
 
 public sealed class IndexTests : TestBase
 {
-    [Test]
+    public IndexTests(TestFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
     public async Task Index_Loads_Successfully_WithLayoutAndNoJavaScriptErrors()
     {
         // Arrange
@@ -27,28 +32,29 @@ public sealed class IndexTests : TestBase
         var response = await page.GotoAsync(path);
 
         // Assert
-        response!.Status.ShouldBe(StatusCodes.Status200OK);
-        hasConsoleErrors.ShouldBeFalse();
+        response!.Status.Should().Be(StatusCodes.Status200OK);
+        hasConsoleErrors.Should().BeFalse();
 
-        (await response.HeaderValueAsync(HeaderNames.ContentType)).ShouldBe("text/html; charset=utf-8");
-        (await response.HeaderValueAsync(HeaderNames.CacheControl)).ShouldBeNull();
-        (await response.HeaderValueAsync(HeaderNames.Pragma)).ShouldBeNull();
+        (await response.HeaderValueAsync(HeaderNames.ContentType)).Should().Be("text/html; charset=utf-8");
+        (await response.HeaderValueAsync(HeaderNames.CacheControl)).Should().BeNull();
+        (await response.HeaderValueAsync(HeaderNames.Pragma)).Should().BeNull();
 
-        (await page.Locator("head > title").TextContentAsync()).ShouldBe(AppConstants.SiteName);
+        (await page.Locator("head > title").TextContentAsync()).Should().Be(AppConstants.SiteName);
 
-        (await page.Locator("head > meta[name='description']").GetAttributeAsync("content")).ShouldBe(
-            AppConstants.SiteDescription);
+        (await page.Locator("head > meta[name='description']").GetAttributeAsync("content"))
+            .Should()
+            .Be(AppConstants.SiteDescription);
 
         var siteHeader = page.Locator("body > div > header > h1").First;
-        (await siteHeader.TextContentAsync()).ShouldBe(AppConstants.SiteName);
-        (await siteHeader.CssValueAsync("font-family")).ShouldContain("Lato");
+        (await siteHeader.TextContentAsync()).Should().Be(AppConstants.SiteName);
+        (await siteHeader.CssValueAsync("font-family")).Should().Contain("Lato");
 
-        (await page.Locator(".container").First.CssValueAsync("max-width")).ShouldBe("768px");
-        (await page.Locator("p").First.CssValueAsync("margin-bottom")).ShouldBe("16px");
-        (await page.Locator(".btn-black").First.CssValueAsync("background-color")).ShouldBe("rgb(0, 0, 0)");
+        (await page.Locator(".container").First.CssValueAsync("max-width")).Should().Be("768px");
+        (await page.Locator("p").First.CssValueAsync("margin-bottom")).Should().Be("16px");
+        (await page.Locator(".btn-black").First.CssValueAsync("background-color")).Should().Be("rgb(0, 0, 0)");
     }
 
-    [Test]
+    [Fact]
     public async Task Index_Click_YouTubeEmbed_NoJavaScript_Success()
     {
         // Arrange
@@ -66,10 +72,10 @@ public sealed class IndexTests : TestBase
         await youTubeEmbed.ClickAsync();
 
         // Assert
-        (await embedContainer.Locator("iframe").IsHiddenAsync()).ShouldBeTrue();
+        (await embedContainer.Locator("iframe").IsHiddenAsync()).Should().BeTrue();
     }
 
-    [Test]
+    [Fact]
     public async Task Index_Click_YouTubeEmbed_WithJavaScript_OnePlayerAtOnce()
     {
         // Arrange
@@ -79,17 +85,18 @@ public sealed class IndexTests : TestBase
         // Act
         await page.GotoAsync(path);
 
-        var youtubeEmbedLinks = page.Locator("a[href^='https://www.youtube.com/watch?v='][aria-label='Play YouTube video']");
+        var youtubeEmbedLinks =
+            page.Locator("a[href^='https://www.youtube.com/watch?v='][aria-label='Play YouTube video']");
         var embedContainer = youtubeEmbedLinks.First.Locator("..").Locator("..");
 
         await youtubeEmbedLinks.First.ClickAsync();
         await youtubeEmbedLinks.Last.ClickAsync();
 
         // Assert
-        (await youtubeEmbedLinks.CountAsync()).ShouldBe(2);
+        (await youtubeEmbedLinks.CountAsync()).Should().Be(2);
 
         var iframes = embedContainer.Locator("iframe");
-        (await iframes.CountAsync()).ShouldBe(1);
-        (await iframes.First.IsVisibleAsync()).ShouldBeTrue();
+        (await iframes.CountAsync()).Should().Be(1);
+        (await iframes.First.IsVisibleAsync()).Should().BeTrue();
     }
 }

--- a/tests/SmoothNanners.Web.Tests.Integration/SmoothNanners.Web.Tests.Integration.csproj
+++ b/tests/SmoothNanners.Web.Tests.Integration/SmoothNanners.Web.Tests.Integration.csproj
@@ -1,15 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0"/>
+        <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
         <PackageReference Include="Microsoft.Playwright" Version="1.58.0"/>
         <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.58.0"/>
-        <PackageReference Include="Shouldly" Version="4.3.0"/>
-        <PackageReference Include="TUnit.Engine" Version="1.16.4" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>
@@ -17,7 +26,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Microsoft.Extensions.Logging"/>
-        <Using Include="Shouldly"/>
+        <Using Include="AwesomeAssertions"/>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 </Project>

--- a/tests/SmoothNanners.Web.Tests.Integration/SmoothNanners.Web.Tests.Integration.csproj
+++ b/tests/SmoothNanners.Web.Tests.Integration/SmoothNanners.Web.Tests.Integration.csproj
@@ -14,7 +14,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3"/>
         <PackageReference Include="Microsoft.Playwright" Version="1.58.0"/>
         <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.58.0"/>
-        <PackageReference Include="xunit.v3" Version="3.2.2"/>
+        <PackageReference Include="xunit.analyzers" Version="1.27.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3.core" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/SmoothNanners.Web.Tests.Integration/SmoothNanners.Web.Tests.Integration.csproj
+++ b/tests/SmoothNanners.Web.Tests.Integration/SmoothNanners.Web.Tests.Integration.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
+        <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     </PropertyGroup>
 
     <ItemGroup>
@@ -11,14 +12,9 @@
         </PackageReference>
         <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
         <PackageReference Include="Microsoft.Playwright" Version="1.58.0"/>
         <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.58.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.v3" Version="3.2.2"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/SmoothNanners.Web.Tests.Integration/TestBase.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/TestBase.cs
@@ -14,6 +14,9 @@ public abstract class TestBase : IAsyncDisposable
         _fixture = fixture;
     }
 
+    /// <summary>
+    /// Disposal that runs after each test method is run.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
         await DisposeAsyncCore();

--- a/tests/SmoothNanners.Web.Tests.Integration/TestBase.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/TestBase.cs
@@ -4,26 +4,23 @@ using SafeRouting;
 
 namespace SmoothNanners.Web.Tests.Integration;
 
-public abstract class TestBase
+public abstract class TestBase : IAsyncDisposable
 {
+    private readonly TestFixture _fixture;
     private readonly IList<IBrowserContext> _browserContexts = [];
 
-    [ClassDataSource<TestFixture>(Shared = SharedType.PerTestSession)]
-    public required TestFixture Fixture { get; init; }
-
-    [Before(TestDiscovery)]
-    public static void BeforeTestDiscovery()
+    protected TestBase(TestFixture fixture)
     {
-        // Install browser binaries needed for Playwright.
-        var exitCode = Microsoft.Playwright.Program.Main(["install", "chromium"]);
-        if (exitCode != 0)
-        {
-            throw new InvalidOperationException($"Playwright browser install exited with code [{exitCode}].");
-        }
+        _fixture = fixture;
     }
 
-    [After(Test)]
-    public async Task AfterTestAsync()
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore();
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual async ValueTask DisposeAsyncCore()
     {
         foreach (var browserContext in _browserContexts)
         {
@@ -33,10 +30,10 @@ public abstract class TestBase
 
     protected async Task<IPage> CreatePageAsync(bool jsEnabled = true)
     {
-        var context = await Fixture.Browser.NewContextAsync(
+        var context = await _fixture.Browser.NewContextAsync(
             new BrowserNewContextOptions
             {
-                BaseURL = Fixture.BaseUrl,
+                BaseURL = _fixture.AppFactory.BaseUrl,
                 JavaScriptEnabled = jsEnabled
             });
 
@@ -49,6 +46,6 @@ public abstract class TestBase
 
     protected string GetPath(IRouteValues route)
     {
-        return route.Path(Fixture.LinkGenerator);
+        return route.Path(_fixture.AppFactory.LinkGenerator);
     }
 }

--- a/tests/SmoothNanners.Web.Tests.Integration/TestFixture.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/TestFixture.cs
@@ -1,31 +1,17 @@
-﻿using Microsoft.AspNetCore.Routing;
-using Microsoft.Playwright;
+﻿using Microsoft.Playwright;
 using Microsoft.Playwright.TestAdapter;
-using TUnit.Core.Interfaces;
 
 namespace SmoothNanners.Web.Tests.Integration;
 
-/// <summary>
-/// Test fixture that should be instantiated only once as a singleton for any tests within the session.
-/// </summary>
-public sealed class TestFixture
-    : IAsyncInitializer,
-        IAsyncDisposable
+public sealed class TestFixture : IAsyncLifetime
 {
-    private readonly AppFactory _appFactory = new();
     private IPlaywright? _playwright;
 
-    public string BaseUrl => _appFactory.BaseUrl;
-
-    public LinkGenerator LinkGenerator => _appFactory.LinkGenerator;
+    public AppFactory AppFactory { get; } = new();
 
     public IBrowser Browser { get; private set; } = null!;
 
-    /// <summary>
-    /// Initialization that should run once when the test session starts.
-    /// </summary>
-    /// <returns>Task.</returns>
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
 #pragma warning disable IDISP003
         _playwright = await Playwright.CreateAsync();
@@ -34,14 +20,10 @@ public sealed class TestFixture
         Browser = await _playwright[PlaywrightSettingsProvider.BrowserName].LaunchAsync();
     }
 
-    /// <summary>
-    /// Async teardown that should run once the test session is finished.
-    /// </summary>
-    /// <returns>ValueTask.</returns>
     public async ValueTask DisposeAsync()
     {
         await Browser.DisposeAsync();
         _playwright?.Dispose();
-        await _appFactory.DisposeAsync();
+        await AppFactory.DisposeAsync();
     }
 }

--- a/tests/SmoothNanners.Web.Tests.Integration/TestFixture.cs
+++ b/tests/SmoothNanners.Web.Tests.Integration/TestFixture.cs
@@ -3,6 +3,10 @@ using Microsoft.Playwright.TestAdapter;
 
 namespace SmoothNanners.Web.Tests.Integration;
 
+/// <summary>
+/// Test fixture that should be configured as an assembly fixture that sets up
+/// services used across all tests before and after all tests are run.
+/// </summary>
 public sealed class TestFixture : IAsyncLifetime
 {
     private IPlaywright? _playwright;

--- a/tests/SmoothNanners.Web.Tests.Integration/xunit.runner.json
+++ b/tests/SmoothNanners.Web.Tests.Integration/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "preEnumerateTheories": true
+}


### PR DESCRIPTION
Use xUnit for tests for better compatibility for test discovery in Rider and simpler test design (less static/attribute based lifecycle and more C# style OOP). Use AwesomeAssertions for more flexible assertion.